### PR TITLE
Custom exception for HTTP errors

### DIFF
--- a/src/tubeulator/api/request.py
+++ b/src/tubeulator/api/request.py
@@ -8,6 +8,7 @@ import httpx
 
 from ..codegen import load_test
 from ..db.store_creds import check_creds
+from ..exc import RequestError
 from ..utils.paths import (
     RefPath,
     SchemaPath,
@@ -470,7 +471,11 @@ class Request:
     path: Path
 
     def __call__(self, *args, **kwargs):
-        result = self.send(*args, **kwargs)
+        try:
+            result = self.send(*args, **kwargs)
+        except httpx.HTTPError as exc:
+            resp = exc.response
+            raise RequestError(response=resp, path=self.path, *args, **kwargs) from None
         parsed = self.parse(result)
         return parsed
 

--- a/src/tubeulator/exc.py
+++ b/src/tubeulator/exc.py
@@ -7,7 +7,7 @@ __all__ = ["RequestError"]
 
 class RequestError(Exception):
     def __init__(self, response: Response, path: Path, *args, **kwargs):
-        path_repr = f"{path.endpoint.name}:{path.route.value}"
+        path_repr = f"{path.endpoint.name}.{path.route.name}:{path.route.value}"
         reason = f"{response.status_code} {response.reason_phrase}"
         message = f"HTTP error at {path_repr} ({list(args)}, {kwargs})\n  {reason}"
         try:

--- a/src/tubeulator/exc.py
+++ b/src/tubeulator/exc.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from httpx import Response
+
+__all__ = ["RequestError"]
+
+
+class RequestError(Exception):
+    def __init__(self, response: Response, path: Path, *args, **kwargs):
+        path_repr = f"{path.endpoint.name}:{path.route.value}"
+        reason = f"{response.status_code} {response.reason_phrase}"
+        message = f"HTTP error at {path_repr} ({list(args)}, {kwargs})\n  {reason}"
+        try:
+            message += f": {response.json()['message']}"
+        except:
+            pass
+        self.message = message
+        self.response = response
+        super().__init__(self.message)


### PR DESCRIPTION
Include the response message, don't show the URL as it contains confidential app credentials (closes #18)