### PR TITLE
Rename models in field annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
 build-backend = "pdm.backend"
-requires = ["pdm-backend"]
+requires = [
+    "pdm-backend",
+]
 
 [project]
 authors = [
-    {email = "louismmx@gmail.com", name = "Louis Maddox"},
+    { email = "louismmx@gmail.com", name = "Louis Maddox" },
 ]
 classifiers = [
     "Intended Audience :: Developers",
@@ -25,7 +27,7 @@ description = "TfL open data interface library."
 name = "tubeulator"
 readme = "README.md"
 requires-python = ">=3.10,<=3.12"
-version = "0.0.4"
+version = "0.0.5"
 
 [project.license]
 text = "MIT"
@@ -64,7 +66,6 @@ ignore = [
 ignore-init-module-imports = true
 select = [
     "C",
-    # "D",
     "E",
     "F",
     "I",

--- a/src/tubeulator/generated/AccidentStats.py
+++ b/src/tubeulator/generated/AccidentStats.py
@@ -19,6 +19,8 @@ class AccidentStatsAccidentDetailArray(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-Api-Presentation-Entities-AccidentStats-AccidentDetailArray')
 
 
+AccidentStatsAccidentDetailArrayModel = AccidentStatsAccidentDetailArray
+
 
 class AccidentDetail(BaseModel):
     """
@@ -36,11 +38,13 @@ class AccidentDetail(BaseModel):
     Date: datetime = None
     Severity: str = None
     Borough: str = None
-    Casualties: list["Casualty"]
-    Vehicles: list["Vehicle"]
+    Casualties: list["CasualtyModel"]
+    Vehicles: list["VehicleModel"]
     _source_schema_name: str = PrivateAttr(default='AccidentStats')
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.AccidentStats.AccidentDetail')
 
+
+AccidentDetailModel = AccidentDetail
 
 
 class Casualty(BaseModel):
@@ -61,6 +65,8 @@ class Casualty(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.AccidentStats.Casualty')
 
 
+CasualtyModel = Casualty
+
 
 class Vehicle(BaseModel):
     """
@@ -75,6 +81,8 @@ class Vehicle(BaseModel):
     _source_schema_name: str = PrivateAttr(default='AccidentStats')
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.AccidentStats.Vehicle')
 
+
+VehicleModel = Vehicle
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/AirQuality.py
+++ b/src/tubeulator/generated/AirQuality.py
@@ -19,6 +19,8 @@ class Object(BaseModel):
     _component_schema_name: str = PrivateAttr(default='System.Object')
 
 
+ObjectModel = Object
+
 
 class Deserialisers(DtoEnum):
     System__Object = Object

--- a/src/tubeulator/generated/BikePoint.py
+++ b/src/tubeulator/generated/BikePoint.py
@@ -19,6 +19,8 @@ class PlaceArray(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-Api-Presentation-Entities-PlaceArray')
 
 
+PlaceArrayModel = PlaceArray
+
 
 class Place(BaseModel):
     """
@@ -34,14 +36,16 @@ class Place(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='BikePoint')
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.Place')
 
+
+PlaceModel = Place
 
 
 class AdditionalProperties(BaseModel):
@@ -61,6 +65,8 @@ class AdditionalProperties(BaseModel):
     _source_schema_name: str = PrivateAttr(default='BikePoint')
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.AdditionalProperties')
 
+
+AdditionalPropertiesModel = AdditionalProperties
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/DisruptionsLiftsv2.py
+++ b/src/tubeulator/generated/DisruptionsLiftsv2.py
@@ -25,6 +25,8 @@ class LiftDisruption(BaseModel):
     _component_schema_name: str = PrivateAttr(default='LiftDisruption')
 
 
+LiftDisruptionModel = LiftDisruption
+
 
 class Get200ApplicationJsonResponse(BaseModel):
     """
@@ -38,6 +40,8 @@ class Get200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Disruptions-Lifts-v2')
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse')
 
+
+Get200ApplicationJsonResponseModel = Get200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Journey.py
+++ b/src/tubeulator/generated/Journey.py
@@ -23,6 +23,8 @@ class Mode(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+ModeModel = Mode
+
 
 class PathAttribute(BaseModel):
     """
@@ -38,6 +40,8 @@ class PathAttribute(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
+
+PathAttributeModel = PathAttribute
 
 
 class InstructionStep(BaseModel):
@@ -59,12 +63,14 @@ class InstructionStep(BaseModel):
     CumulativeTravelTime: int = None
     Latitude: float = None
     Longitude: float = None
-    PathAttribute: PathAttribute = None
+    PathAttribute: PathAttributeModel = None
     DescriptionHeading: str = None
     TrackType: str = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
+
+InstructionStepModel = InstructionStep
 
 
 class Instruction(BaseModel):
@@ -78,10 +84,12 @@ class Instruction(BaseModel):
 
     Summary: str = None
     Detailed: str = None
-    Steps: list["InstructionStep"]
+    Steps: list["InstructionStepModel"]
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-4')
 
+
+InstructionModel = Instruction
 
 
 class Obstacle(BaseModel):
@@ -101,6 +109,8 @@ class Obstacle(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-5')
 
 
+ObstacleModel = Obstacle
+
 
 class Point(BaseModel):
     """
@@ -117,6 +127,8 @@ class Point(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-6')
 
 
+PointModel = Point
+
 
 class PassengerFlow(BaseModel):
     """
@@ -132,6 +144,8 @@ class PassengerFlow(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-7')
 
+
+PassengerFlowModel = PassengerFlow
 
 
 class TrainLoading(BaseModel):
@@ -154,6 +168,8 @@ class TrainLoading(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-8')
 
 
+TrainLoadingModel = TrainLoading
+
 
 class Crowding(BaseModel):
     """
@@ -164,11 +180,13 @@ class Crowding(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    PassengerFlows: list["PassengerFlow"]
-    TrainLoadings: list["TrainLoading"]
+    PassengerFlows: list["PassengerFlowModel"]
+    TrainLoadings: list["TrainLoadingModel"]
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-9')
 
+
+CrowdingModel = Crowding
 
 
 class Identifier(BaseModel):
@@ -185,12 +203,14 @@ class Identifier(BaseModel):
     Uri: str = None
     FullName: str = None
     Type: str = None
-    Crowding: Crowding = None
+    Crowding: CrowdingModel = None
     RouteType: str = None
     Status: str = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-10')
 
+
+IdentifierModel = Identifier
 
 
 class JpElevation(BaseModel):
@@ -213,6 +233,8 @@ class JpElevation(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-11')
 
 
+JpElevationModel = JpElevation
+
 
 class Path(BaseModel):
     """
@@ -224,11 +246,13 @@ class Path(BaseModel):
     )
 
     LineString: str = None
-    StopPoints: list["Identifier"]
-    Elevation: list["JpElevation"]
+    StopPoints: list["IdentifierModel"]
+    Elevation: list["JpElevationModel"]
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-12')
 
+
+PathModel = Path
 
 
 class RouteOption(BaseModel):
@@ -243,10 +267,12 @@ class RouteOption(BaseModel):
     Id: str = None
     Name: str = None
     Directions: list[str]
-    LineIdentifier: Identifier = None
+    LineIdentifier: IdentifierModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-13')
 
+
+RouteOptionModel = RouteOption
 
 
 class LineGroup(BaseModel):
@@ -265,6 +291,8 @@ class LineGroup(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-14')
 
 
+LineGroupModel = LineGroup
+
 
 class LineModeGroup(BaseModel):
     """
@@ -280,6 +308,8 @@ class LineModeGroup(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-15')
 
+
+LineModeGroupModel = LineModeGroup
 
 
 class AdditionalProperties(BaseModel):
@@ -300,6 +330,8 @@ class AdditionalProperties(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-16')
 
 
+AdditionalPropertiesModel = AdditionalProperties
+
 
 class Place(BaseModel):
     """
@@ -315,14 +347,16 @@ class Place(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-17')
 
+
+PlaceModel = Place
 
 
 class StopPoint(BaseModel):
@@ -345,9 +379,9 @@ class StopPoint(BaseModel):
     StationNaptan: str = None
     AccessibilitySummary: str = None
     HubNaptanCode: str = None
-    Lines: list["Identifier"]
-    LineGroup: list["LineGroup"]
-    LineModeGroups: list["LineModeGroup"]
+    Lines: list["IdentifierModel"]
+    LineGroup: list["LineGroupModel"]
+    LineModeGroups: list["LineModeGroupModel"]
     FullName: str = None
     NaptanMode: str = None
     Status: bool = None
@@ -356,14 +390,16 @@ class StopPoint(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-18')
 
+
+StopPointModel = StopPoint
 
 
 class RouteSectionNaptanEntrySequence(BaseModel):
@@ -376,10 +412,12 @@ class RouteSectionNaptanEntrySequence(BaseModel):
     )
 
     Ordinal: int = None
-    StopPoint: StopPoint = None
+    StopPoint: StopPointModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-19')
 
+
+RouteSectionNaptanEntrySequenceModel = RouteSectionNaptanEntrySequence
 
 
 class RouteSection(BaseModel):
@@ -401,10 +439,12 @@ class RouteSection(BaseModel):
     DestinationName: str = None
     ValidTo: datetime = None
     ValidFrom: datetime = None
-    RouteSectionNaptanEntrySequence: list["RouteSectionNaptanEntrySequence"]
+    RouteSectionNaptanEntrySequence: list["RouteSectionNaptanEntrySequenceModel"]
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-20')
 
+
+RouteSectionModel = RouteSection
 
 
 class Disruption(BaseModel):
@@ -424,12 +464,14 @@ class Disruption(BaseModel):
     AdditionalInfo: str = None
     Created: datetime = None
     LastUpdate: datetime = None
-    AffectedRoutes: list["RouteSection"]
-    AffectedStops: list["StopPoint"]
+    AffectedRoutes: list["RouteSectionModel"]
+    AffectedStops: list["StopPointModel"]
     ClosureText: str = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-21')
 
+
+DisruptionModel = Disruption
 
 
 class PlannedWork(BaseModel):
@@ -449,6 +491,8 @@ class PlannedWork(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-22')
 
 
+PlannedWorkModel = PlannedWork
+
 
 class Leg(BaseModel):
     """
@@ -461,23 +505,25 @@ class Leg(BaseModel):
 
     Duration: int = None
     Speed: str = None
-    Instruction: Instruction = None
-    Obstacles: list["Obstacle"]
+    Instruction: InstructionModel = None
+    Obstacles: list["ObstacleModel"]
     DepartureTime: datetime = None
     ArrivalTime: datetime = None
-    DeparturePoint: Point = None
-    ArrivalPoint: Point = None
-    Path: Path = None
-    RouteOptions: list["RouteOption"]
-    Mode: Identifier = None
-    Disruptions: list["Disruption"]
-    PlannedWorks: list["PlannedWork"]
+    DeparturePoint: PointModel = None
+    ArrivalPoint: PointModel = None
+    Path: PathModel = None
+    RouteOptions: list["RouteOptionModel"]
+    Mode: IdentifierModel = None
+    Disruptions: list["DisruptionModel"]
+    PlannedWorks: list["PlannedWorkModel"]
     Distance: float = None
     IsDisrupted: bool = None
     HasFixedLocations: bool = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-23')
 
+
+LegModel = Leg
 
 
 class FareTapDetails(BaseModel):
@@ -499,6 +545,8 @@ class FareTapDetails(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-24')
 
 
+FareTapDetailsModel = FareTapDetails
+
 
 class FareTap(BaseModel):
     """
@@ -510,10 +558,12 @@ class FareTap(BaseModel):
     )
 
     AtcoCode: str = None
-    TapDetails: FareTapDetails = None
+    TapDetails: FareTapDetailsModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-25')
 
+
+FareTapModel = FareTap
 
 
 class Fare(BaseModel):
@@ -533,10 +583,12 @@ class Fare(BaseModel):
     ChargeLevel: str = None
     Peak: int = None
     OffPeak: int = None
-    Taps: list["FareTap"]
+    Taps: list["FareTapModel"]
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-26')
 
+
+FareModel = Fare
 
 
 class FareCaveat(BaseModel):
@@ -554,6 +606,8 @@ class FareCaveat(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-27')
 
 
+FareCaveatModel = FareCaveat
+
 
 class JourneyFare(BaseModel):
     """
@@ -565,11 +619,13 @@ class JourneyFare(BaseModel):
     )
 
     TotalCost: int = None
-    Fares: list["Fare"]
-    Caveats: list["FareCaveat"]
+    Fares: list["FareModel"]
+    Caveats: list["FareCaveatModel"]
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-28')
 
+
+JourneyFareModel = JourneyFare
 
 
 class Journey(BaseModel):
@@ -584,11 +640,13 @@ class Journey(BaseModel):
     StartDateTime: datetime = None
     Duration: int = None
     ArrivalDateTime: datetime = None
-    Legs: list["Leg"]
-    Fare: JourneyFare = None
+    Legs: list["LegModel"]
+    Fare: JourneyFareModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-29')
 
+
+JourneyModel = Journey
 
 
 class ValidityPeriod(BaseModel):
@@ -607,6 +665,8 @@ class ValidityPeriod(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-30')
 
 
+ValidityPeriodModel = ValidityPeriod
+
 
 class LineStatus(BaseModel):
     """
@@ -624,11 +684,13 @@ class LineStatus(BaseModel):
     Reason: str = None
     Created: datetime = None
     Modified: datetime = None
-    ValidityPeriods: list["ValidityPeriod"]
-    Disruption: Disruption = None
+    ValidityPeriods: list["ValidityPeriodModel"]
+    Disruption: DisruptionModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-31')
 
+
+LineStatusModel = LineStatus
 
 
 class MatchedRoute(BaseModel):
@@ -654,6 +716,8 @@ class MatchedRoute(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-32')
 
 
+MatchedRouteModel = MatchedRoute
+
 
 class LineServiceTypeInfo(BaseModel):
     """
@@ -670,6 +734,8 @@ class LineServiceTypeInfo(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-33')
 
 
+LineServiceTypeInfoModel = LineServiceTypeInfo
+
 
 class Line(BaseModel):
     """
@@ -683,16 +749,18 @@ class Line(BaseModel):
     Id: str = None
     Name: str = None
     ModeName: str = None
-    Disruptions: list["Disruption"]
+    Disruptions: list["DisruptionModel"]
     Created: datetime = None
     Modified: datetime = None
-    LineStatuses: list["LineStatus"]
-    RouteSections: list["MatchedRoute"]
-    ServiceTypes: list["LineServiceTypeInfo"]
-    Crowding: Crowding = None
+    LineStatuses: list["LineStatusModel"]
+    RouteSections: list["MatchedRouteModel"]
+    ServiceTypes: list["LineServiceTypeInfoModel"]
+    Crowding: CrowdingModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-34')
 
+
+LineModel = Line
 
 
 class JourneyPlannerCycleHireDockingStationData(BaseModel):
@@ -714,6 +782,8 @@ class JourneyPlannerCycleHireDockingStationData(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-35')
 
 
+JourneyPlannerCycleHireDockingStationDataModel = JourneyPlannerCycleHireDockingStationData
+
 
 class TimeAdjustment(BaseModel):
     """
@@ -732,6 +802,8 @@ class TimeAdjustment(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-36')
 
 
+TimeAdjustmentModel = TimeAdjustment
+
 
 class TimeAdjustments(BaseModel):
     """
@@ -742,13 +814,15 @@ class TimeAdjustments(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    Earliest: TimeAdjustment = None
-    Earlier: TimeAdjustment = None
-    Later: TimeAdjustment = None
-    Latest: TimeAdjustment = None
+    Earliest: TimeAdjustmentModel = None
+    Earlier: TimeAdjustmentModel = None
+    Later: TimeAdjustmentModel = None
+    Latest: TimeAdjustmentModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-37')
 
+
+TimeAdjustmentsModel = TimeAdjustments
 
 
 class SearchCriteria(BaseModel):
@@ -762,10 +836,12 @@ class SearchCriteria(BaseModel):
 
     DateTime: datetime = None
     DateTimeType: str = None
-    TimeAdjustments: TimeAdjustments = None
+    TimeAdjustments: TimeAdjustmentsModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-38')
 
+
+SearchCriteriaModel = SearchCriteria
 
 
 class JourneyVector(BaseModel):
@@ -785,6 +861,8 @@ class JourneyVector(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-39')
 
 
+JourneyVectorModel = JourneyVector
+
 
 class ItineraryResult(BaseModel):
     """
@@ -795,16 +873,18 @@ class ItineraryResult(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    Journeys: list["Journey"]
-    Lines: list["Line"]
-    CycleHireDockingStationData: JourneyPlannerCycleHireDockingStationData = None
+    Journeys: list["JourneyModel"]
+    Lines: list["LineModel"]
+    CycleHireDockingStationData: JourneyPlannerCycleHireDockingStationDataModel = None
     StopMessages: list[str]
     RecommendedMaxAgeMinutes: int = None
-    SearchCriteria: SearchCriteria = None
-    JourneyVector: JourneyVector = None
+    SearchCriteria: SearchCriteriaModel = None
+    JourneyVector: JourneyVectorModel = None
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Tfl-40')
 
+
+ItineraryResultModel = ItineraryResult
 
 
 class MetaModesGet200ApplicationJsonResponse(BaseModel):
@@ -820,6 +900,8 @@ class MetaModesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaModesGet200ApplicationJsonResponse')
 
 
+MetaModesGet200ApplicationJsonResponseModel = MetaModesGet200ApplicationJsonResponse
+
 
 class Get200ApplicationJsonResponse(BaseModel):
     """
@@ -833,6 +915,8 @@ class Get200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Journey')
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse')
 
+
+Get200ApplicationJsonResponseModel = Get200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Line.py
+++ b/src/tubeulator/generated/Line.py
@@ -23,6 +23,8 @@ class Mode(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+ModeModel = Mode
+
 
 class StatusSeverity(BaseModel):
     """
@@ -40,6 +42,8 @@ class StatusSeverity(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
 
+StatusSeverityModel = StatusSeverity
+
 
 class PassengerFlow(BaseModel):
     """
@@ -55,6 +59,8 @@ class PassengerFlow(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
+
+PassengerFlowModel = PassengerFlow
 
 
 class TrainLoading(BaseModel):
@@ -77,6 +83,8 @@ class TrainLoading(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-4')
 
 
+TrainLoadingModel = TrainLoading
+
 
 class Crowding(BaseModel):
     """
@@ -87,11 +95,13 @@ class Crowding(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    PassengerFlows: list["PassengerFlow"]
-    TrainLoadings: list["TrainLoading"]
+    PassengerFlows: list["PassengerFlowModel"]
+    TrainLoadings: list["TrainLoadingModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-5')
 
+
+CrowdingModel = Crowding
 
 
 class Identifier(BaseModel):
@@ -108,12 +118,14 @@ class Identifier(BaseModel):
     Uri: str = None
     FullName: str = None
     Type: str = None
-    Crowding: Crowding = None
+    Crowding: CrowdingModel = None
     RouteType: str = None
     Status: str = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-6')
 
+
+IdentifierModel = Identifier
 
 
 class LineGroup(BaseModel):
@@ -132,6 +144,8 @@ class LineGroup(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-7')
 
 
+LineGroupModel = LineGroup
+
 
 class LineModeGroup(BaseModel):
     """
@@ -147,6 +161,8 @@ class LineModeGroup(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-8')
 
+
+LineModeGroupModel = LineModeGroup
 
 
 class AdditionalProperties(BaseModel):
@@ -167,6 +183,8 @@ class AdditionalProperties(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-9')
 
 
+AdditionalPropertiesModel = AdditionalProperties
+
 
 class Place(BaseModel):
     """
@@ -182,14 +200,16 @@ class Place(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-10')
 
+
+PlaceModel = Place
 
 
 class StopPoint(BaseModel):
@@ -212,9 +232,9 @@ class StopPoint(BaseModel):
     StationNaptan: str = None
     AccessibilitySummary: str = None
     HubNaptanCode: str = None
-    Lines: list["Identifier"]
-    LineGroup: list["LineGroup"]
-    LineModeGroups: list["LineModeGroup"]
+    Lines: list["IdentifierModel"]
+    LineGroup: list["LineGroupModel"]
+    LineModeGroups: list["LineModeGroupModel"]
     FullName: str = None
     NaptanMode: str = None
     Status: bool = None
@@ -223,14 +243,16 @@ class StopPoint(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-11')
 
+
+StopPointModel = StopPoint
 
 
 class RouteSectionNaptanEntrySequence(BaseModel):
@@ -243,10 +265,12 @@ class RouteSectionNaptanEntrySequence(BaseModel):
     )
 
     Ordinal: int = None
-    StopPoint: StopPoint = None
+    StopPoint: StopPointModel = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-12')
 
+
+RouteSectionNaptanEntrySequenceModel = RouteSectionNaptanEntrySequence
 
 
 class RouteSection(BaseModel):
@@ -268,10 +292,12 @@ class RouteSection(BaseModel):
     DestinationName: str = None
     ValidTo: datetime = None
     ValidFrom: datetime = None
-    RouteSectionNaptanEntrySequence: list["RouteSectionNaptanEntrySequence"]
+    RouteSectionNaptanEntrySequence: list["RouteSectionNaptanEntrySequenceModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-13')
 
+
+RouteSectionModel = RouteSection
 
 
 class Disruption(BaseModel):
@@ -291,12 +317,14 @@ class Disruption(BaseModel):
     AdditionalInfo: str = None
     Created: datetime = None
     LastUpdate: datetime = None
-    AffectedRoutes: list["RouteSection"]
-    AffectedStops: list["StopPoint"]
+    AffectedRoutes: list["RouteSectionModel"]
+    AffectedStops: list["StopPointModel"]
     ClosureText: str = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-14')
 
+
+DisruptionModel = Disruption
 
 
 class ValidityPeriod(BaseModel):
@@ -315,6 +343,8 @@ class ValidityPeriod(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-15')
 
 
+ValidityPeriodModel = ValidityPeriod
+
 
 class LineStatus(BaseModel):
     """
@@ -332,11 +362,13 @@ class LineStatus(BaseModel):
     Reason: str = None
     Created: datetime = None
     Modified: datetime = None
-    ValidityPeriods: list["ValidityPeriod"]
-    Disruption: Disruption = None
+    ValidityPeriods: list["ValidityPeriodModel"]
+    Disruption: DisruptionModel = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-16')
 
+
+LineStatusModel = LineStatus
 
 
 class MatchedRoute(BaseModel):
@@ -362,6 +394,8 @@ class MatchedRoute(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-17')
 
 
+MatchedRouteModel = MatchedRoute
+
 
 class LineServiceTypeInfo(BaseModel):
     """
@@ -378,6 +412,8 @@ class LineServiceTypeInfo(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-18')
 
 
+LineServiceTypeInfoModel = LineServiceTypeInfo
+
 
 class Line(BaseModel):
     """
@@ -391,16 +427,18 @@ class Line(BaseModel):
     Id: str = None
     Name: str = None
     ModeName: str = None
-    Disruptions: list["Disruption"]
+    Disruptions: list["DisruptionModel"]
     Created: datetime = None
     Modified: datetime = None
-    LineStatuses: list["LineStatus"]
-    RouteSections: list["MatchedRoute"]
-    ServiceTypes: list["LineServiceTypeInfo"]
-    Crowding: Crowding = None
+    LineStatuses: list["LineStatusModel"]
+    RouteSections: list["MatchedRouteModel"]
+    ServiceTypes: list["LineServiceTypeInfoModel"]
+    Crowding: CrowdingModel = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-19')
 
+
+LineModel = Line
 
 
 class MatchedStop(BaseModel):
@@ -425,7 +463,7 @@ class MatchedStop(BaseModel):
     Zone: str = None
     AccessibilitySummary: str = None
     HasDisruption: bool = None
-    Lines: list["Identifier"]
+    Lines: list["IdentifierModel"]
     Status: bool = None
     Id: str = None
     Url: str = None
@@ -435,6 +473,8 @@ class MatchedStop(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-20')
 
+
+MatchedStopModel = MatchedStop
 
 
 class StopPointSequence(BaseModel):
@@ -452,11 +492,13 @@ class StopPointSequence(BaseModel):
     BranchId: int = None
     NextBranchIds: list[int]
     PrevBranchIds: list[int]
-    StopPoint: list["MatchedStop"]
+    StopPoint: list["MatchedStopModel"]
     ServiceType: str = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-21')
 
+
+StopPointSequenceModel = StopPointSequence
 
 
 class OrderedRoute(BaseModel):
@@ -475,6 +517,8 @@ class OrderedRoute(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-22')
 
 
+OrderedRouteModel = OrderedRoute
+
 
 class RouteSequence(BaseModel):
     """
@@ -491,12 +535,14 @@ class RouteSequence(BaseModel):
     IsOutboundOnly: bool = None
     Mode: str = None
     LineStrings: list[str]
-    Stations: list["MatchedStop"]
-    StopPointSequences: list["StopPointSequence"]
-    OrderedLineRoutes: list["OrderedRoute"]
+    Stations: list["MatchedStopModel"]
+    StopPointSequences: list["StopPointSequenceModel"]
+    OrderedLineRoutes: list["OrderedRouteModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-23')
 
+
+RouteSequenceModel = RouteSequence
 
 
 class LineRouteSection(BaseModel):
@@ -519,6 +565,8 @@ class LineRouteSection(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-24')
 
 
+LineRouteSectionModel = LineRouteSection
+
 
 class MatchedRouteSections(BaseModel):
     """
@@ -534,6 +582,8 @@ class MatchedRouteSections(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-25')
 
 
+MatchedRouteSectionsModel = MatchedRouteSections
+
 
 class RouteSearchMatch(BaseModel):
     """
@@ -547,9 +597,9 @@ class RouteSearchMatch(BaseModel):
     LineId: str = None
     Mode: str = None
     LineName: str = None
-    LineRouteSection: list["LineRouteSection"]
-    MatchedRouteSections: list["MatchedRouteSections"]
-    MatchedStops: list["MatchedStop"]
+    LineRouteSection: list["LineRouteSectionModel"]
+    MatchedRouteSections: list["MatchedRouteSectionsModel"]
+    MatchedStops: list["MatchedStopModel"]
     Id: str = None
     Url: str = None
     Name: str = None
@@ -558,6 +608,8 @@ class RouteSearchMatch(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-26')
 
+
+RouteSearchMatchModel = RouteSearchMatch
 
 
 class RouteSearchResponse(BaseModel):
@@ -570,10 +622,12 @@ class RouteSearchResponse(BaseModel):
     )
 
     Input: str = None
-    SearchMatches: list["RouteSearchMatch"]
+    SearchMatches: list["RouteSearchMatchModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-27')
 
+
+RouteSearchResponseModel = RouteSearchResponse
 
 
 class Interval(BaseModel):
@@ -591,6 +645,8 @@ class Interval(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-28')
 
 
+IntervalModel = Interval
+
 
 class StationInterval(BaseModel):
     """
@@ -602,10 +658,12 @@ class StationInterval(BaseModel):
     )
 
     Id: str = None
-    Intervals: list["Interval"]
+    Intervals: list["IntervalModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-29')
 
+
+StationIntervalModel = StationInterval
 
 
 class KnownJourney(BaseModel):
@@ -624,6 +682,8 @@ class KnownJourney(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-30')
 
 
+KnownJourneyModel = KnownJourney
+
 
 class TwentyFourHourClockTime(BaseModel):
     """
@@ -639,6 +699,8 @@ class TwentyFourHourClockTime(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-31')
 
+
+TwentyFourHourClockTimeModel = TwentyFourHourClockTime
 
 
 class ServiceFrequency(BaseModel):
@@ -656,6 +718,8 @@ class ServiceFrequency(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-32')
 
 
+ServiceFrequencyModel = ServiceFrequency
+
 
 class Period(BaseModel):
     """
@@ -667,12 +731,14 @@ class Period(BaseModel):
     )
 
     Type: str = None
-    FromTime: TwentyFourHourClockTime = None
-    ToTime: TwentyFourHourClockTime = None
-    Frequency: ServiceFrequency = None
+    FromTime: TwentyFourHourClockTimeModel = None
+    ToTime: TwentyFourHourClockTimeModel = None
+    Frequency: ServiceFrequencyModel = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-33')
 
+
+PeriodModel = Period
 
 
 class Schedule(BaseModel):
@@ -685,13 +751,15 @@ class Schedule(BaseModel):
     )
 
     Name: str = None
-    KnownJourneys: list["KnownJourney"]
-    FirstJourney: KnownJourney = None
-    LastJourney: KnownJourney = None
-    Periods: list["Period"]
+    KnownJourneys: list["KnownJourneyModel"]
+    FirstJourney: KnownJourneyModel = None
+    LastJourney: KnownJourneyModel = None
+    Periods: list["PeriodModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-34')
 
+
+ScheduleModel = Schedule
 
 
 class TimetableRoute(BaseModel):
@@ -703,11 +771,13 @@ class TimetableRoute(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    StationIntervals: list["StationInterval"]
-    Schedules: list["Schedule"]
+    StationIntervals: list["StationIntervalModel"]
+    Schedules: list["ScheduleModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-35')
 
+
+TimetableRouteModel = TimetableRoute
 
 
 class Timetable(BaseModel):
@@ -720,10 +790,12 @@ class Timetable(BaseModel):
     )
 
     DepartureStopId: str = None
-    Routes: list["TimetableRoute"]
+    Routes: list["TimetableRouteModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-36')
 
+
+TimetableModel = Timetable
 
 
 class DisambiguationOption(BaseModel):
@@ -741,6 +813,8 @@ class DisambiguationOption(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-37')
 
 
+DisambiguationOptionModel = DisambiguationOption
+
 
 class Disambiguation(BaseModel):
     """
@@ -751,10 +825,12 @@ class Disambiguation(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    DisambiguationOptions: list["DisambiguationOption"]
+    DisambiguationOptions: list["DisambiguationOptionModel"]
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-38')
 
+
+DisambiguationModel = Disambiguation
 
 
 class TimetableResponse(BaseModel):
@@ -770,14 +846,16 @@ class TimetableResponse(BaseModel):
     LineName: str = None
     Direction: str = None
     PdfUrl: str = None
-    Stations: list["MatchedStop"]
-    Stops: list["MatchedStop"]
-    Timetable: Timetable = None
-    Disambiguation: Disambiguation = None
+    Stations: list["MatchedStopModel"]
+    Stops: list["MatchedStopModel"]
+    Timetable: TimetableModel = None
+    Disambiguation: DisambiguationModel = None
     StatusErrorMessage: str = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-39')
 
+
+TimetableResponseModel = TimetableResponse
 
 
 class PredictionTiming(BaseModel):
@@ -798,6 +876,8 @@ class PredictionTiming(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-40')
 
+
+PredictionTimingModel = PredictionTiming
 
 
 class Prediction(BaseModel):
@@ -828,10 +908,12 @@ class Prediction(BaseModel):
     ExpectedArrival: datetime = None
     TimeToLive: datetime = None
     ModeName: str = None
-    Timing: PredictionTiming = None
+    Timing: PredictionTimingModel = None
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Tfl-41')
 
+
+PredictionModel = Prediction
 
 
 class MetaModesGet200ApplicationJsonResponse(BaseModel):
@@ -847,6 +929,8 @@ class MetaModesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaModesGet200ApplicationJsonResponse')
 
 
+MetaModesGet200ApplicationJsonResponseModel = MetaModesGet200ApplicationJsonResponse
+
 
 class Get200ApplicationJsonResponse(BaseModel):
     """
@@ -860,6 +944,8 @@ class Get200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse')
 
+
+Get200ApplicationJsonResponseModel = Get200ApplicationJsonResponse
 
 
 class MetaSeverityGet200ApplicationJsonResponse(BaseModel):
@@ -875,6 +961,8 @@ class MetaSeverityGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaSeverityGet200ApplicationJsonResponse')
 
 
+MetaSeverityGet200ApplicationJsonResponseModel = MetaSeverityGet200ApplicationJsonResponse
+
 
 class MetaDisruptionCategories(BaseModel):
     """
@@ -888,6 +976,8 @@ class MetaDisruptionCategories(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='MetaDisruptionCategoriesGet200ApplicationJsonResponse')
 
+
+MetaDisruptionCategoriesModel = MetaDisruptionCategories
 
 
 class MetaServiceTypes(BaseModel):
@@ -903,6 +993,8 @@ class MetaServiceTypes(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaServiceTypesGet200ApplicationJsonResponse')
 
 
+MetaServiceTypesModel = MetaServiceTypes
+
 
 class idsGet200ApplicationJsonResponse(BaseModel):
     """
@@ -916,6 +1008,8 @@ class idsGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='ids-Get200ApplicationJsonResponse')
 
+
+idsGet200ApplicationJsonResponseModel = idsGet200ApplicationJsonResponse
 
 
 class ModemodesGet200ApplicationJsonResponse(BaseModel):
@@ -931,6 +1025,8 @@ class ModemodesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Mode-modes-Get200ApplicationJsonResponse')
 
 
+ModemodesGet200ApplicationJsonResponseModel = ModemodesGet200ApplicationJsonResponse
+
 
 class RouteGet200ApplicationJsonResponse(BaseModel):
     """
@@ -944,6 +1040,8 @@ class RouteGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='RouteGet200ApplicationJsonResponse')
 
+
+RouteGet200ApplicationJsonResponseModel = RouteGet200ApplicationJsonResponse
 
 
 class idsRouteGet200ApplicationJsonResponse(BaseModel):
@@ -959,6 +1057,8 @@ class idsRouteGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ids-RouteGet200ApplicationJsonResponse')
 
 
+idsRouteGet200ApplicationJsonResponseModel = idsRouteGet200ApplicationJsonResponse
+
 
 class ModemodesRouteGet200ApplicationJsonResponse(BaseModel):
     """
@@ -972,6 +1072,8 @@ class ModemodesRouteGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Mode-modes-RouteGet200ApplicationJsonResponse')
 
+
+ModemodesRouteGet200ApplicationJsonResponseModel = ModemodesRouteGet200ApplicationJsonResponse
 
 
 class idsStatusstartDateToendDateGet200ApplicationJsonResponse(BaseModel):
@@ -987,6 +1089,8 @@ class idsStatusstartDateToendDateGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ids-Status-startDate-To-endDate-Get200ApplicationJsonResponse')
 
 
+idsStatusstartDateToendDateGet200ApplicationJsonResponseModel = idsStatusstartDateToendDateGet200ApplicationJsonResponse
+
 
 class idsStatusGet200ApplicationJsonResponse(BaseModel):
     """
@@ -1000,6 +1104,8 @@ class idsStatusGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='ids-StatusGet200ApplicationJsonResponse')
 
+
+idsStatusGet200ApplicationJsonResponseModel = idsStatusGet200ApplicationJsonResponse
 
 
 class StatusseverityGet200ApplicationJsonResponse(BaseModel):
@@ -1015,6 +1121,8 @@ class StatusseverityGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Status-severity-Get200ApplicationJsonResponse')
 
 
+StatusseverityGet200ApplicationJsonResponseModel = StatusseverityGet200ApplicationJsonResponse
+
 
 class ModemodesStatusGet200ApplicationJsonResponse(BaseModel):
     """
@@ -1028,6 +1136,8 @@ class ModemodesStatusGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='Mode-modes-StatusGet200ApplicationJsonResponse')
 
+
+ModemodesStatusGet200ApplicationJsonResponseModel = ModemodesStatusGet200ApplicationJsonResponse
 
 
 class idStopPointsGet200ApplicationJsonResponse(BaseModel):
@@ -1043,6 +1153,8 @@ class idStopPointsGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='id-StopPointsGet200ApplicationJsonResponse')
 
 
+idStopPointsGet200ApplicationJsonResponseModel = idStopPointsGet200ApplicationJsonResponse
+
 
 class idsDisruptionGet200ApplicationJsonResponse(BaseModel):
     """
@@ -1056,6 +1168,8 @@ class idsDisruptionGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='ids-DisruptionGet200ApplicationJsonResponse')
 
+
+idsDisruptionGet200ApplicationJsonResponseModel = idsDisruptionGet200ApplicationJsonResponse
 
 
 class ModemodesDisruptionGet200ApplicationJsonResponse(BaseModel):
@@ -1071,6 +1185,8 @@ class ModemodesDisruptionGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Mode-modes-DisruptionGet200ApplicationJsonResponse')
 
 
+ModemodesDisruptionGet200ApplicationJsonResponseModel = ModemodesDisruptionGet200ApplicationJsonResponse
+
 
 class idsArrivalsstopPointIdGet200ApplicationJsonResponse(BaseModel):
     """
@@ -1085,6 +1201,8 @@ class idsArrivalsstopPointIdGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ids-Arrivals-stopPointId-Get200ApplicationJsonResponse')
 
 
+idsArrivalsstopPointIdGet200ApplicationJsonResponseModel = idsArrivalsstopPointIdGet200ApplicationJsonResponse
+
 
 class idsArrivalsGet200ApplicationJsonResponse(BaseModel):
     """
@@ -1098,6 +1216,8 @@ class idsArrivalsGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Line')
     _component_schema_name: str = PrivateAttr(default='ids-ArrivalsGet200ApplicationJsonResponse')
 
+
+idsArrivalsGet200ApplicationJsonResponseModel = idsArrivalsGet200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Mode.py
+++ b/src/tubeulator/generated/Mode.py
@@ -19,6 +19,8 @@ class ActiveServiceTypeArray(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-Api-Presentation-Entities-ActiveServiceTypeArray')
 
 
+ActiveServiceTypeArrayModel = ActiveServiceTypeArray
+
 
 class ActiveServiceType(BaseModel):
     """
@@ -35,6 +37,8 @@ class ActiveServiceType(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.ActiveServiceType')
 
 
+ActiveServiceTypeModel = ActiveServiceType
+
 
 class PredictionArray(BaseModel):
     """
@@ -48,6 +52,8 @@ class PredictionArray(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Mode')
     _component_schema_name: str = PrivateAttr(default='Tfl-Api-Presentation-Entities-PredictionArray-4')
 
+
+PredictionArrayModel = PredictionArray
 
 
 class Prediction(BaseModel):
@@ -78,10 +84,12 @@ class Prediction(BaseModel):
     ExpectedArrival: datetime = None
     TimeToLive: datetime = None
     ModeName: str = None
-    Timing: PredictionTiming = None
+    Timing: PredictionTimingModel = None
     _source_schema_name: str = PrivateAttr(default='Mode')
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.Prediction')
 
+
+PredictionModel = Prediction
 
 
 class PredictionTiming(BaseModel):
@@ -102,6 +110,8 @@ class PredictionTiming(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Mode')
     _component_schema_name: str = PrivateAttr(default='Tfl.Api.Presentation.Entities.PredictionTiming')
 
+
+PredictionTimingModel = PredictionTiming
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Place.py
+++ b/src/tubeulator/generated/Place.py
@@ -21,6 +21,8 @@ class PlaceCategory(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+PlaceCategoryModel = PlaceCategory
+
 
 class AdditionalProperties(BaseModel):
     """
@@ -40,6 +42,8 @@ class AdditionalProperties(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
 
+AdditionalPropertiesModel = AdditionalProperties
+
 
 class Place(BaseModel):
     """
@@ -55,14 +59,16 @@ class Place(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
+
+PlaceModel = Place
 
 
 class PassengerFlow(BaseModel):
@@ -79,6 +85,8 @@ class PassengerFlow(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='Tfl-4')
 
+
+PassengerFlowModel = PassengerFlow
 
 
 class TrainLoading(BaseModel):
@@ -101,6 +109,8 @@ class TrainLoading(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-5')
 
 
+TrainLoadingModel = TrainLoading
+
 
 class Crowding(BaseModel):
     """
@@ -111,11 +121,13 @@ class Crowding(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    PassengerFlows: list["PassengerFlow"]
-    TrainLoadings: list["TrainLoading"]
+    PassengerFlows: list["PassengerFlowModel"]
+    TrainLoadings: list["TrainLoadingModel"]
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='Tfl-6')
 
+
+CrowdingModel = Crowding
 
 
 class Identifier(BaseModel):
@@ -132,12 +144,14 @@ class Identifier(BaseModel):
     Uri: str = None
     FullName: str = None
     Type: str = None
-    Crowding: Crowding = None
+    Crowding: CrowdingModel = None
     RouteType: str = None
     Status: str = None
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='Tfl-7')
 
+
+IdentifierModel = Identifier
 
 
 class LineGroup(BaseModel):
@@ -156,6 +170,8 @@ class LineGroup(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-8')
 
 
+LineGroupModel = LineGroup
+
 
 class LineModeGroup(BaseModel):
     """
@@ -171,6 +187,8 @@ class LineModeGroup(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='Tfl-9')
 
+
+LineModeGroupModel = LineModeGroup
 
 
 class StopPoint(BaseModel):
@@ -193,9 +211,9 @@ class StopPoint(BaseModel):
     StationNaptan: str = None
     AccessibilitySummary: str = None
     HubNaptanCode: str = None
-    Lines: list["Identifier"]
-    LineGroup: list["LineGroup"]
-    LineModeGroups: list["LineModeGroup"]
+    Lines: list["IdentifierModel"]
+    LineGroup: list["LineGroupModel"]
+    LineModeGroups: list["LineModeGroupModel"]
     FullName: str = None
     NaptanMode: str = None
     Status: bool = None
@@ -204,14 +222,16 @@ class StopPoint(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='Tfl-10')
 
+
+StopPointModel = StopPoint
 
 
 class Object(BaseModel):
@@ -227,6 +247,8 @@ class Object(BaseModel):
     _component_schema_name: str = PrivateAttr(default='System')
 
 
+ObjectModel = Object
+
 
 class MetaCategoriesGet200ApplicationJsonResponse(BaseModel):
     """
@@ -240,6 +262,8 @@ class MetaCategoriesGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='MetaCategoriesGet200ApplicationJsonResponse')
 
+
+MetaCategoriesGet200ApplicationJsonResponseModel = MetaCategoriesGet200ApplicationJsonResponse
 
 
 class Get200ApplicationJsonResponse(BaseModel):
@@ -255,6 +279,8 @@ class Get200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse')
 
 
+Get200ApplicationJsonResponseModel = Get200ApplicationJsonResponse
+
 
 class MetaPlaceTypesGet200ApplicationJsonResponse(BaseModel):
     """
@@ -268,6 +294,8 @@ class MetaPlaceTypesGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='MetaPlaceTypesGet200ApplicationJsonResponse')
 
+
+MetaPlaceTypesGet200ApplicationJsonResponseModel = MetaPlaceTypesGet200ApplicationJsonResponse
 
 
 class TypetypesGet200ApplicationJsonResponse(BaseModel):
@@ -283,6 +311,8 @@ class TypetypesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Type-types-Get200ApplicationJsonResponse')
 
 
+TypetypesGet200ApplicationJsonResponseModel = TypetypesGet200ApplicationJsonResponse
+
 
 class idGet200ApplicationJsonResponse(BaseModel):
     """
@@ -296,6 +326,8 @@ class idGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='id-Get200ApplicationJsonResponse')
 
+
+idGet200ApplicationJsonResponseModel = idGet200ApplicationJsonResponse
 
 
 class ApplicationJsonResponse(BaseModel):
@@ -311,6 +343,8 @@ class ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse-1')
 
 
+ApplicationJsonResponseModel = ApplicationJsonResponse
+
 
 class SearchGet200ApplicationJsonResponse(BaseModel):
     """
@@ -324,6 +358,8 @@ class SearchGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Place')
     _component_schema_name: str = PrivateAttr(default='SearchGet200ApplicationJsonResponse')
 
+
+SearchGet200ApplicationJsonResponseModel = SearchGet200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Road.py
+++ b/src/tubeulator/generated/Road.py
@@ -29,6 +29,8 @@ class RoadCorridor(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+RoadCorridorModel = RoadCorridor
+
 
 class DbGeographyWellKnownValue(BaseModel):
     """
@@ -46,6 +48,8 @@ class DbGeographyWellKnownValue(BaseModel):
     _component_schema_name: str = PrivateAttr(default='System')
 
 
+DbGeographyWellKnownValueModel = DbGeographyWellKnownValue
+
 
 class DbGeography(BaseModel):
     """
@@ -56,10 +60,12 @@ class DbGeography(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    Geography: DbGeographyWellKnownValue = None
+    Geography: DbGeographyWellKnownValueModel = None
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='System-2')
 
+
+DbGeographyModel = DbGeography
 
 
 class StreetSegment(BaseModel):
@@ -79,6 +85,8 @@ class StreetSegment(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
 
+StreetSegmentModel = StreetSegment
+
 
 class Street(BaseModel):
     """
@@ -92,12 +100,14 @@ class Street(BaseModel):
     Name: str = None
     Closure: str = None
     Directions: str = None
-    Segments: list["StreetSegment"]
+    Segments: list["StreetSegmentModel"]
     SourceSystemId: int = None
     SourceSystemKey: str = None
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
+
+StreetModel = Street
 
 
 class RoadProject(BaseModel):
@@ -130,6 +140,8 @@ class RoadProject(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-4')
 
 
+RoadProjectModel = RoadProject
+
 
 class RoadDisruptionLine(BaseModel):
     """
@@ -143,7 +155,7 @@ class RoadDisruptionLine(BaseModel):
     Id: int = None
     RoadDisruptionId: str = None
     IsDiversion: bool = None
-    MultiLineString: DbGeography = None
+    MultiLineString: DbGeographyModel = None
     StartDate: datetime = None
     EndDate: datetime = None
     StartTime: str = None
@@ -151,6 +163,8 @@ class RoadDisruptionLine(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='Tfl-5')
 
+
+RoadDisruptionLineModel = RoadDisruptionLine
 
 
 class RoadDisruptionImpactArea(BaseModel):
@@ -164,7 +178,7 @@ class RoadDisruptionImpactArea(BaseModel):
 
     Id: int = None
     RoadDisruptionId: str = None
-    Polygon: DbGeography = None
+    Polygon: DbGeographyModel = None
     StartDate: datetime = None
     EndDate: datetime = None
     StartTime: str = None
@@ -172,6 +186,8 @@ class RoadDisruptionImpactArea(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='Tfl-6')
 
+
+RoadDisruptionImpactAreaModel = RoadDisruptionImpactArea
 
 
 class RoadDisruptionSchedule(BaseModel):
@@ -188,6 +204,8 @@ class RoadDisruptionSchedule(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='Tfl-7')
 
+
+RoadDisruptionScheduleModel = RoadDisruptionSchedule
 
 
 class RoadDisruption(BaseModel):
@@ -216,23 +234,25 @@ class RoadDisruption(BaseModel):
     LevelOfInterest: str = None
     Location: str = None
     Status: str = None
-    Geography: DbGeography = None
-    Geometry: DbGeography = None
-    Streets: list["Street"]
+    Geography: DbGeographyModel = None
+    Geometry: DbGeographyModel = None
+    Streets: list["StreetModel"]
     IsProvisional: bool = None
     HasClosures: bool = None
     LinkText: str = None
     LinkUrl: str = None
-    RoadProject: RoadProject = None
+    RoadProject: RoadProjectModel = None
     PublishStartDate: datetime = None
     PublishEndDate: datetime = None
     TimeFrame: str = None
-    RoadDisruptionLines: list["RoadDisruptionLine"]
-    RoadDisruptionImpactAreas: list["RoadDisruptionImpactArea"]
-    RecurringSchedules: list["RoadDisruptionSchedule"]
+    RoadDisruptionLines: list["RoadDisruptionLineModel"]
+    RoadDisruptionImpactAreas: list["RoadDisruptionImpactAreaModel"]
+    RecurringSchedules: list["RoadDisruptionScheduleModel"]
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='Tfl-8')
 
+
+RoadDisruptionModel = RoadDisruption
 
 
 class Object(BaseModel):
@@ -247,6 +267,8 @@ class Object(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='System-3')
 
+
+ObjectModel = Object
 
 
 class StatusSeverity(BaseModel):
@@ -265,6 +287,8 @@ class StatusSeverity(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-9')
 
 
+StatusSeverityModel = StatusSeverity
+
 
 class Get200ApplicationJsonResponse(BaseModel):
     """
@@ -278,6 +302,8 @@ class Get200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse')
 
+
+Get200ApplicationJsonResponseModel = Get200ApplicationJsonResponse
 
 
 class idsGet200ApplicationJsonResponse(BaseModel):
@@ -293,6 +319,8 @@ class idsGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ids-Get200ApplicationJsonResponse')
 
 
+idsGet200ApplicationJsonResponseModel = idsGet200ApplicationJsonResponse
+
 
 class idsStatusGet200ApplicationJsonResponse(BaseModel):
     """
@@ -306,6 +334,8 @@ class idsStatusGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='ids-StatusGet200ApplicationJsonResponse')
 
+
+idsStatusGet200ApplicationJsonResponseModel = idsStatusGet200ApplicationJsonResponse
 
 
 class idsDisruptionGet200ApplicationJsonResponse(BaseModel):
@@ -321,6 +351,8 @@ class idsDisruptionGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ids-DisruptionGet200ApplicationJsonResponse')
 
 
+idsDisruptionGet200ApplicationJsonResponseModel = idsDisruptionGet200ApplicationJsonResponse
+
 
 class MetaCategories(BaseModel):
     """
@@ -335,6 +367,8 @@ class MetaCategories(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaCategoriesGet200ApplicationJsonResponse')
 
 
+MetaCategoriesModel = MetaCategories
+
 
 class MetaSeveritiesGet200ApplicationJsonResponse(BaseModel):
     """
@@ -348,6 +382,8 @@ class MetaSeveritiesGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Road')
     _component_schema_name: str = PrivateAttr(default='MetaSeveritiesGet200ApplicationJsonResponse')
 
+
+MetaSeveritiesGet200ApplicationJsonResponseModel = MetaSeveritiesGet200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Search.py
+++ b/src/tubeulator/generated/Search.py
@@ -24,6 +24,8 @@ class SearchMatch(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+SearchMatchModel = SearchMatch
+
 
 class SearchResponse(BaseModel):
     """
@@ -40,11 +42,13 @@ class SearchResponse(BaseModel):
     PageSize: int = None
     Provider: str = None
     Total: int = None
-    Matches: list["SearchMatch"]
+    Matches: list["SearchMatchModel"]
     MaxScore: float = None
     _source_schema_name: str = PrivateAttr(default='Search')
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
+
+SearchResponseModel = SearchResponse
 
 
 class MetaSearchProviders(BaseModel):
@@ -60,6 +64,8 @@ class MetaSearchProviders(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaSearchProvidersGet200ApplicationJsonResponse')
 
 
+MetaSearchProvidersModel = MetaSearchProviders
+
 
 class MetaCategories(BaseModel):
     """
@@ -74,6 +80,8 @@ class MetaCategories(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaCategoriesGet200ApplicationJsonResponse')
 
 
+MetaCategoriesModel = MetaCategories
+
 
 class MetaSorts(BaseModel):
     """
@@ -87,6 +95,8 @@ class MetaSorts(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Search')
     _component_schema_name: str = PrivateAttr(default='MetaSortsGet200ApplicationJsonResponse')
 
+
+MetaSortsModel = MetaSorts
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/StopPoint.py
+++ b/src/tubeulator/generated/StopPoint.py
@@ -21,6 +21,8 @@ class PlaceCategory(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+PlaceCategoryModel = PlaceCategory
+
 
 class Mode(BaseModel):
     """
@@ -39,6 +41,8 @@ class Mode(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
 
+ModeModel = Mode
+
 
 class PassengerFlow(BaseModel):
     """
@@ -54,6 +58,8 @@ class PassengerFlow(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
+
+PassengerFlowModel = PassengerFlow
 
 
 class TrainLoading(BaseModel):
@@ -76,6 +82,8 @@ class TrainLoading(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-4')
 
 
+TrainLoadingModel = TrainLoading
+
 
 class Crowding(BaseModel):
     """
@@ -86,11 +94,13 @@ class Crowding(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    PassengerFlows: list["PassengerFlow"]
-    TrainLoadings: list["TrainLoading"]
+    PassengerFlows: list["PassengerFlowModel"]
+    TrainLoadings: list["TrainLoadingModel"]
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-5')
 
+
+CrowdingModel = Crowding
 
 
 class Identifier(BaseModel):
@@ -107,12 +117,14 @@ class Identifier(BaseModel):
     Uri: str = None
     FullName: str = None
     Type: str = None
-    Crowding: Crowding = None
+    Crowding: CrowdingModel = None
     RouteType: str = None
     Status: str = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-6')
 
+
+IdentifierModel = Identifier
 
 
 class LineGroup(BaseModel):
@@ -131,6 +143,8 @@ class LineGroup(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-7')
 
 
+LineGroupModel = LineGroup
+
 
 class LineModeGroup(BaseModel):
     """
@@ -146,6 +160,8 @@ class LineModeGroup(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-8')
 
+
+LineModeGroupModel = LineModeGroup
 
 
 class AdditionalProperties(BaseModel):
@@ -166,6 +182,8 @@ class AdditionalProperties(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-9')
 
 
+AdditionalPropertiesModel = AdditionalProperties
+
 
 class Place(BaseModel):
     """
@@ -181,14 +199,16 @@ class Place(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-10')
 
+
+PlaceModel = Place
 
 
 class StopPoint(BaseModel):
@@ -211,9 +231,9 @@ class StopPoint(BaseModel):
     StationNaptan: str = None
     AccessibilitySummary: str = None
     HubNaptanCode: str = None
-    Lines: list["Identifier"]
-    LineGroup: list["LineGroup"]
-    LineModeGroups: list["LineModeGroup"]
+    Lines: list["IdentifierModel"]
+    LineGroup: list["LineGroupModel"]
+    LineModeGroups: list["LineModeGroupModel"]
     FullName: str = None
     NaptanMode: str = None
     Status: bool = None
@@ -222,14 +242,16 @@ class StopPoint(BaseModel):
     CommonName: str = None
     Distance: float = None
     PlaceType: str = None
-    AdditionalProperties: list["AdditionalProperties"]
-    Children: list["Place"]
+    AdditionalProperties: list["AdditionalPropertiesModel"]
+    Children: list["PlaceModel"]
     ChildrenUrls: list[str]
     Lat: float = None
     Lon: float = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-11')
 
+
+StopPointModel = StopPoint
 
 
 class LineServiceTypeInfo(BaseModel):
@@ -247,6 +269,8 @@ class LineServiceTypeInfo(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-12')
 
 
+LineServiceTypeInfoModel = LineServiceTypeInfo
+
 
 class LineSpecificServiceType(BaseModel):
     """
@@ -257,11 +281,13 @@ class LineSpecificServiceType(BaseModel):
         alias_generator=AliasGenerator(validation_alias=to_camel_case),
     )
 
-    ServiceType: LineServiceTypeInfo = None
+    ServiceType: LineServiceTypeInfoModel = None
     StopServesServiceType: bool = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-13')
 
+
+LineSpecificServiceTypeModel = LineSpecificServiceType
 
 
 class LineServiceType(BaseModel):
@@ -274,10 +300,12 @@ class LineServiceType(BaseModel):
     )
 
     LineName: str = None
-    LineSpecificServiceTypes: list["LineSpecificServiceType"]
+    LineSpecificServiceTypes: list["LineSpecificServiceTypeModel"]
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-14')
 
+
+LineServiceTypeModel = LineServiceType
 
 
 class PredictionTiming(BaseModel):
@@ -298,6 +326,8 @@ class PredictionTiming(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-15')
 
+
+PredictionTimingModel = PredictionTiming
 
 
 class Prediction(BaseModel):
@@ -328,10 +358,12 @@ class Prediction(BaseModel):
     ExpectedArrival: datetime = None
     TimeToLive: datetime = None
     ModeName: str = None
-    Timing: PredictionTiming = None
+    Timing: PredictionTimingModel = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-16')
 
+
+PredictionModel = Prediction
 
 
 class ArrivalDeparture(BaseModel):
@@ -356,10 +388,12 @@ class ArrivalDeparture(BaseModel):
     MinutesAndSecondsToDeparture: str = None
     Cause: str = None
     DepartureStatus: str = None
-    Timing: PredictionTiming = None
+    Timing: PredictionTimingModel = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-17')
 
+
+ArrivalDepartureModel = ArrivalDeparture
 
 
 class StopPointRouteSection(BaseModel):
@@ -387,6 +421,8 @@ class StopPointRouteSection(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-18')
 
 
+StopPointRouteSectionModel = StopPointRouteSection
+
 
 class DisruptedPoint(BaseModel):
     """
@@ -411,6 +447,8 @@ class DisruptedPoint(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-19')
 
 
+DisruptedPointModel = DisruptedPoint
+
 
 class StopPointsResponse(BaseModel):
     """
@@ -422,13 +460,15 @@ class StopPointsResponse(BaseModel):
     )
 
     CentrePoint: list[float]
-    StopPoints: list["StopPoint"]
+    StopPoints: list["StopPointModel"]
     PageSize: int = None
     Total: int = None
     Page: int = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-20')
 
+
+StopPointsResponseModel = StopPointsResponse
 
 
 class SearchMatch(BaseModel):
@@ -449,6 +489,8 @@ class SearchMatch(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-21')
 
 
+SearchMatchModel = SearchMatch
+
 
 class SearchResponse(BaseModel):
     """
@@ -465,11 +507,13 @@ class SearchResponse(BaseModel):
     PageSize: int = None
     Provider: str = None
     Total: int = None
-    Matches: list["SearchMatch"]
+    Matches: list["SearchMatchModel"]
     MaxScore: float = None
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Tfl-22')
 
+
+SearchResponseModel = SearchResponse
 
 
 class Object(BaseModel):
@@ -485,6 +529,8 @@ class Object(BaseModel):
     _component_schema_name: str = PrivateAttr(default='System')
 
 
+ObjectModel = Object
+
 
 class Get200ApplicationJsonResponse(BaseModel):
     """
@@ -498,6 +544,8 @@ class Get200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Get200ApplicationJsonResponse')
 
+
+Get200ApplicationJsonResponseModel = Get200ApplicationJsonResponse
 
 
 class MetaCategoriesGet200ApplicationJsonResponse(BaseModel):
@@ -513,6 +561,8 @@ class MetaCategoriesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaCategoriesGet200ApplicationJsonResponse')
 
 
+MetaCategoriesGet200ApplicationJsonResponseModel = MetaCategoriesGet200ApplicationJsonResponse
+
 
 class MetaStopTypes(BaseModel):
     """
@@ -526,6 +576,8 @@ class MetaStopTypes(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='MetaStopTypesGet200ApplicationJsonResponse')
 
+
+MetaStopTypesModel = MetaStopTypes
 
 
 class MetaModesGet200ApplicationJsonResponse(BaseModel):
@@ -541,6 +593,8 @@ class MetaModesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='MetaModesGet200ApplicationJsonResponse')
 
 
+MetaModesGet200ApplicationJsonResponseModel = MetaModesGet200ApplicationJsonResponse
+
 
 class idsGet200ApplicationJsonResponse(BaseModel):
     """
@@ -554,6 +608,8 @@ class idsGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='ids-Get200ApplicationJsonResponse')
 
+
+idsGet200ApplicationJsonResponseModel = idsGet200ApplicationJsonResponse
 
 
 class idPlaceTypesGet200ApplicationJsonResponse(BaseModel):
@@ -569,6 +625,8 @@ class idPlaceTypesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='id-PlaceTypesGet200ApplicationJsonResponse')
 
 
+idPlaceTypesGet200ApplicationJsonResponseModel = idPlaceTypesGet200ApplicationJsonResponse
+
 
 class idCrowdinglineGet200ApplicationJsonResponse(BaseModel):
     """
@@ -582,6 +640,8 @@ class idCrowdinglineGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='id-Crowding-line-Get200ApplicationJsonResponse')
 
+
+idCrowdinglineGet200ApplicationJsonResponseModel = idCrowdinglineGet200ApplicationJsonResponse
 
 
 class TypetypesGet200ApplicationJsonResponse(BaseModel):
@@ -597,6 +657,8 @@ class TypetypesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Type-types-Get200ApplicationJsonResponse')
 
 
+TypetypesGet200ApplicationJsonResponseModel = TypetypesGet200ApplicationJsonResponse
+
 
 class TypetypesPagepageGet200ApplicationJsonResponse(BaseModel):
     """
@@ -610,6 +672,8 @@ class TypetypesPagepageGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Type-types-Page-page-Get200ApplicationJsonResponse')
 
+
+TypetypesPagepageGet200ApplicationJsonResponseModel = TypetypesPagepageGet200ApplicationJsonResponse
 
 
 class ServiceTypesGet200ApplicationJsonResponse(BaseModel):
@@ -625,6 +689,8 @@ class ServiceTypesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ServiceTypesGet200ApplicationJsonResponse')
 
 
+ServiceTypesGet200ApplicationJsonResponseModel = ServiceTypesGet200ApplicationJsonResponse
+
 
 class idArrivalsGet200ApplicationJsonResponse(BaseModel):
     """
@@ -638,6 +704,8 @@ class idArrivalsGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='id-ArrivalsGet200ApplicationJsonResponse')
 
+
+idArrivalsGet200ApplicationJsonResponseModel = idArrivalsGet200ApplicationJsonResponse
 
 
 class idArrivalDeparturesGet200ApplicationJsonResponse(BaseModel):
@@ -653,6 +721,8 @@ class idArrivalDeparturesGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='id-ArrivalDeparturesGet200ApplicationJsonResponse')
 
 
+idArrivalDeparturesGet200ApplicationJsonResponseModel = idArrivalDeparturesGet200ApplicationJsonResponse
+
 
 class idCanReachOnLinelineIdGet200ApplicationJsonResponse(BaseModel):
     """
@@ -666,6 +736,8 @@ class idCanReachOnLinelineIdGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='id-CanReachOnLine-lineId-Get200ApplicationJsonResponse')
 
+
+idCanReachOnLinelineIdGet200ApplicationJsonResponseModel = idCanReachOnLinelineIdGet200ApplicationJsonResponse
 
 
 class idRouteGet200ApplicationJsonResponse(BaseModel):
@@ -681,6 +753,8 @@ class idRouteGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='id-RouteGet200ApplicationJsonResponse')
 
 
+idRouteGet200ApplicationJsonResponseModel = idRouteGet200ApplicationJsonResponse
+
 
 class ModemodesDisruptionGet200ApplicationJsonResponse(BaseModel):
     """
@@ -694,6 +768,8 @@ class ModemodesDisruptionGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='Mode-modes-DisruptionGet200ApplicationJsonResponse')
 
+
+ModemodesDisruptionGet200ApplicationJsonResponseModel = ModemodesDisruptionGet200ApplicationJsonResponse
 
 
 class idsDisruptionGet200ApplicationJsonResponse(BaseModel):
@@ -709,6 +785,8 @@ class idsDisruptionGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ids-DisruptionGet200ApplicationJsonResponse')
 
 
+idsDisruptionGet200ApplicationJsonResponseModel = idsDisruptionGet200ApplicationJsonResponse
+
 
 class idDirectionTotoStopPointIdGet200ApplicationJsonResponse(BaseModel):
     """
@@ -722,6 +800,8 @@ class idDirectionTotoStopPointIdGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='id-DirectionTo-toStopPointId-Get200ApplicationJsonResponse')
 
+
+idDirectionTotoStopPointIdGet200ApplicationJsonResponseModel = idDirectionTotoStopPointIdGet200ApplicationJsonResponse
 
 
 class stopPointIdTaxiRanksGet200ApplicationJsonResponse(BaseModel):
@@ -737,6 +817,8 @@ class stopPointIdTaxiRanksGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='stopPointId-TaxiRanksGet200ApplicationJsonResponse')
 
 
+stopPointIdTaxiRanksGet200ApplicationJsonResponseModel = stopPointIdTaxiRanksGet200ApplicationJsonResponse
+
 
 class stopPointIdCarParksGet200ApplicationJsonResponse(BaseModel):
     """
@@ -750,6 +832,8 @@ class stopPointIdCarParksGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='StopPoint')
     _component_schema_name: str = PrivateAttr(default='stopPointId-CarParksGet200ApplicationJsonResponse')
 
+
+stopPointIdCarParksGet200ApplicationJsonResponseModel = stopPointIdCarParksGet200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/Vehicle.py
+++ b/src/tubeulator/generated/Vehicle.py
@@ -25,6 +25,8 @@ class PredictionTiming(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+PredictionTimingModel = PredictionTiming
+
 
 class Prediction(BaseModel):
     """
@@ -54,10 +56,12 @@ class Prediction(BaseModel):
     ExpectedArrival: datetime = None
     TimeToLive: datetime = None
     ModeName: str = None
-    Timing: PredictionTiming = None
+    Timing: PredictionTimingModel = None
     _source_schema_name: str = PrivateAttr(default='Vehicle')
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
+
+PredictionModel = Prediction
 
 
 class VehicleMatch(BaseModel):
@@ -79,6 +83,8 @@ class VehicleMatch(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
 
+VehicleMatchModel = VehicleMatch
+
 
 class idsArrivalsGet200ApplicationJsonResponse(BaseModel):
     """
@@ -92,6 +98,8 @@ class idsArrivalsGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='Vehicle')
     _component_schema_name: str = PrivateAttr(default='ids-ArrivalsGet200ApplicationJsonResponse')
 
+
+idsArrivalsGet200ApplicationJsonResponseModel = idsArrivalsGet200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):

--- a/src/tubeulator/generated/occupancy.py
+++ b/src/tubeulator/generated/occupancy.py
@@ -23,6 +23,8 @@ class Bay(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl')
 
 
+BayModel = Bay
+
 
 class CarParkOccupancy(BaseModel):
     """
@@ -34,12 +36,14 @@ class CarParkOccupancy(BaseModel):
     )
 
     Id: str = None
-    Bays: list["Bay"]
+    Bays: list["BayModel"]
     Name: str = None
     CarParkDetailsUrl: str = None
     _source_schema_name: str = PrivateAttr(default='occupancy')
     _component_schema_name: str = PrivateAttr(default='Tfl-2')
 
+
+CarParkOccupancyModel = CarParkOccupancy
 
 
 class ChargeConnectorOccupancy(BaseModel):
@@ -57,6 +61,8 @@ class ChargeConnectorOccupancy(BaseModel):
     _source_schema_name: str = PrivateAttr(default='occupancy')
     _component_schema_name: str = PrivateAttr(default='Tfl-3')
 
+
+ChargeConnectorOccupancyModel = ChargeConnectorOccupancy
 
 
 class BikePointOccupancy(BaseModel):
@@ -77,6 +83,8 @@ class BikePointOccupancy(BaseModel):
     _component_schema_name: str = PrivateAttr(default='Tfl-4')
 
 
+BikePointOccupancyModel = BikePointOccupancy
+
 
 class CarParkGet200ApplicationJsonResponse(BaseModel):
     """
@@ -90,6 +98,8 @@ class CarParkGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='occupancy')
     _component_schema_name: str = PrivateAttr(default='CarParkGet200ApplicationJsonResponse')
 
+
+CarParkGet200ApplicationJsonResponseModel = CarParkGet200ApplicationJsonResponse
 
 
 class ChargeConnectoridsGet200ApplicationJsonResponse(BaseModel):
@@ -105,6 +115,8 @@ class ChargeConnectoridsGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ChargeConnector-ids-Get200ApplicationJsonResponse')
 
 
+ChargeConnectoridsGet200ApplicationJsonResponseModel = ChargeConnectoridsGet200ApplicationJsonResponse
+
 
 class ChargeConnectorGet200ApplicationJsonResponse(BaseModel):
     """
@@ -119,6 +131,8 @@ class ChargeConnectorGet200ApplicationJsonResponse(BaseModel):
     _component_schema_name: str = PrivateAttr(default='ChargeConnectorGet200ApplicationJsonResponse')
 
 
+ChargeConnectorGet200ApplicationJsonResponseModel = ChargeConnectorGet200ApplicationJsonResponse
+
 
 class BikePointsidsGet200ApplicationJsonResponse(BaseModel):
     """
@@ -132,6 +146,8 @@ class BikePointsidsGet200ApplicationJsonResponse(BaseModel):
     _source_schema_name: str = PrivateAttr(default='occupancy')
     _component_schema_name: str = PrivateAttr(default='BikePoints-ids-Get200ApplicationJsonResponse')
 
+
+BikePointsidsGet200ApplicationJsonResponseModel = BikePointsidsGet200ApplicationJsonResponse
 
 
 class Deserialisers(DtoEnum):


### PR DESCRIPTION
- fix: reassign model to new name so field annotation doesn't match referent model name (closes #26)
- chore: bump -> v0.0.5

As suggested in https://github.com/pydantic/pydantic/issues/9093

> `Aaa: Aaa = None` seems to be the same as [#8243 (comment)](https://github.com/pydantic/pydantic/pull/8243#issuecomment-1831900199), and can be very misleading as the `Aaa` annotation will take the value of `None`.

This fix generates a new name assignment after each model declaration, and these names are used in the models as field annotations. For example the `Crowding: CrowdingModel` annotation of the `Identifier` model class in the `Journey` codegen'd module:

```py
class Crowding(BaseModel):
    """
    Autogenerated from Journey::Tfl.Api.Presentation.Entities.Crowding
    """

    model_config = ConfigDict(
        alias_generator=AliasGenerator(validation_alias=to_camel_case),
    )

    PassengerFlows: list["PassengerFlowModel"]
    TrainLoadings: list["TrainLoadingModel"]
    _source_schema_name: str = PrivateAttr(default='Journey')
    _component_schema_name: str = PrivateAttr(default='Tfl-9')


CrowdingModel = Crowding


class Identifier(BaseModel):
    """
    Autogenerated from Journey::Tfl.Api.Presentation.Entities.Identifier
    """

    model_config = ConfigDict(
        alias_generator=AliasGenerator(validation_alias=to_camel_case),
    )

    Id: str = None
    Name: str = None
    Uri: str = None
    FullName: str = None
    Type: str = None
    Crowding: CrowdingModel = None
    RouteType: str = None
    Status: str = None
    _source_schema_name: str = PrivateAttr(default='Journey')
    _component_schema_name: str = PrivateAttr(default='Tfl-10')

IdentifierModel = Identifier
```