### PR TITLE
chore: bump docs to 3.12

### DIFF
--- a/docs/vercel/deploy.sh
+++ b/docs/vercel/deploy.sh
@@ -9,4 +9,4 @@ echo "UV VERSION"
 uv --version
 
 echo "SYNCING DOCS + VERCEL DEPS"
-uv sync --python 3.11 --frozen --no-default-groups --group docs
+uv sync --python 3.12 --frozen --no-default-groups --group docs


### PR DESCRIPTION
3.12 breaks the docs build